### PR TITLE
Refactor AdmissionService.admit to reduce cognitive complexity

### DIFF
--- a/helm/psa-restricted-patcher/Chart.yaml
+++ b/helm/psa-restricted-patcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: psa-restricted-patcher
 description: Automatically patches pods on creation to conform to the pod security restricted profile
 type: application
-version: 0.10.0
-appVersion: "0.4.0"
+version: 0.10.1
+appVersion: "0.4.1"
 maintainers:
   - name: bryopsida

--- a/helm/psa-restricted-patcher/README.md
+++ b/helm/psa-restricted-patcher/README.md
@@ -1,6 +1,6 @@
 # psa-restricted-patcher
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 Automatically patches pods on creation to conform to the pod security restricted profile
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psa-restricted-patcher",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "psa-restricted-patcher",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/under-pressure": "^8.1.0",
@@ -3453,9 +3453,9 @@
       "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA=="
     },
     "node_modules/fastify": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.18.0.tgz",
-      "integrity": "sha512-L5o/2GEkBastQ3HV0dtKo7SUZ497Z1+q4fcqAoPyq6JCQ/8zdk1JQEoTQwnBWCp+EmA7AQa6mxNqSAEhzP0RwQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.19.2.tgz",
+      "integrity": "sha512-2unheeIRWFf9/Jjcz7djOpKuXCTzZjlyFfiBwKqpldkHMN2rfTLu/f9pYTdwlhzC9Cdj0S2H12zlug0Kd5uZ1w==",
       "dependencies": {
         "@fastify/ajv-compiler": "^3.5.0",
         "@fastify/error": "^3.2.0",
@@ -9842,9 +9842,9 @@
       "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA=="
     },
     "fastify": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.18.0.tgz",
-      "integrity": "sha512-L5o/2GEkBastQ3HV0dtKo7SUZ497Z1+q4fcqAoPyq6JCQ/8zdk1JQEoTQwnBWCp+EmA7AQa6mxNqSAEhzP0RwQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.19.2.tgz",
+      "integrity": "sha512-2unheeIRWFf9/Jjcz7djOpKuXCTzZjlyFfiBwKqpldkHMN2rfTLu/f9pYTdwlhzC9Cdj0S2H12zlug0Kd5uZ1w==",
       "requires": {
         "@fastify/ajv-compiler": "^3.5.0",
         "@fastify/error": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psa-restricted-patcher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Automatically patches pods on creation to comply with the restricted pod security admission policy",
   "main": "dist/app.js",
   "scripts": {

--- a/src/services/admission.ts
+++ b/src/services/admission.ts
@@ -89,7 +89,7 @@ export class Admission implements IAdmission {
         type: this.seccompProfile
       }
     }
-    spec.containers = spec.containers.map(this.patchContainer)
+    spec.containers = spec.containers.map(this.patchContainer.bind(this))
     return Promise.resolve(JSON.stringify(jsonpatch.generate(observer)))
   }
 }


### PR DESCRIPTION
Fixes sonar cognitive complexity code smell by splitting the pod level patching and container level patching into separate methods.